### PR TITLE
Do not require `sidekiq_application_metrics`

### DIFF
--- a/lib/g5_prom_rails/metrics.rb
+++ b/lib/g5_prom_rails/metrics.rb
@@ -1,4 +1,4 @@
-require_relative 'sidekiq_application_metrics'
+require_relative 'sidekiq_application_metrics' if defined?(Sidekiq)
 
 class G5PromRails::MetricsContainer
   if defined?(Sidekiq)


### PR DESCRIPTION
Do not require `sidekiq_application_metrics` unless Sidekiq is defined.

Otherwise you will get the following error:

```
 /Users/ava/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `require': cannot load such file -- sidekiq/api (LoadError)
 	from /Users/ava/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `block in require'
 	from /Users/ava/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:259:in `load_dependency'
 	from /Users/ava/.rvm/gems/ruby-2.3.1/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `require'
 	from /Users/ava/.rvm/gems/ruby-2.3.1/gems/g5_prom_rails-0.3.1/lib/g5_prom_rails/sidekiq_application_metrics.rb:1:in `<top (required)>'
 	from /Users/ava/.rvm/gems/ruby-2.3.1/gems/g5_prom_rails-0.3.1/lib/g5_prom_rails/metrics.rb:1:in `require_relative'
 	from /Users/ava/.rvm/gems/ruby-2.3.1/gems/g5_prom_rails-0.3.1/lib/g5_prom_rails/metrics.rb:1:in `<top (required)>'
 	from /Users/ava/.rvm/gems/ruby-2.3.1/gems/g5_prom_rails-0.3.1/lib/g5_prom_rails/engine.rb:2:in `require_relative'
 	from /Users/ava/.rvm/gems/ruby-2.3.1/gems/g5_prom_rails-0.3.1/lib/g5_prom_rails/engine.rb:2:in `<top (required)>'
```