### PR TITLE
Allow prometheus-client up to 0.9.x, but no further

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    g5_prom_rails (0.3.1)
-      prometheus-client (~> 0.7.0)
+    g5_prom_rails (0.3.2)
+      prometheus-client (< 0.10.0)
       rails (>= 4.0.0)
 
 GEM
@@ -51,25 +51,23 @@ GEM
     connection_pool (2.2.1)
     diff-lcs (1.3)
     erubi (1.6.0)
-    globalid (0.4.0)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (0.8.4)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.6)
-      mime-types (>= 1.16, < 4)
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
     method_source (0.8.2)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mini_mime (1.0.2)
     mini_portile2 (2.2.0)
     minitest (5.10.2)
-    nio4r (2.1.0)
+    nio4r (2.5.2)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
-    prometheus-client (0.7.1)
-      quantile (~> 0.2.0)
-    quantile (0.2.0)
+    prometheus-client (0.9.0)
+      quantile (~> 0.2.1)
+    quantile (0.2.1)
     rack (2.0.3)
     rack-protection (2.0.0)
       rack
@@ -122,10 +120,10 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.3, >= 3.3.3)
-    sprockets (3.7.1)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.0)
+    sprockets-rails (3.2.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -138,7 +136,7 @@ GEM
       tzinfo (>= 1.0.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.4)
 
 PLATFORMS
   ruby
@@ -151,4 +149,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.15.3
+   1.17.2

--- a/g5_prom_rails.gemspec
+++ b/g5_prom_rails.gemspec
@@ -17,7 +17,11 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 4.0.0"
-  s.add_dependency "prometheus-client", "~> 0.7.0"
+  # 0.10 introduces breaking changes that will require changes in this gem, but
+  # also changes in any application that consumes this and has custom metrics
+  #
+  # https://github.com/prometheus/client_ruby/blob/master/UPGRADING.md
+  s.add_dependency "prometheus-client", "< 0.10.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"

--- a/lib/g5_prom_rails/version.rb
+++ b/lib/g5_prom_rails/version.rb
@@ -1,3 +1,3 @@
 module G5PromRails
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end


### PR DESCRIPTION
Later versions will require a breaking change in g5_prom_rails, which
I'm unlikely to want to deal with. See comment in gemspec.